### PR TITLE
XfsFileSystemTest style

### DIFF
--- a/src/test/java/org/jnode/fs/service/FileSystemService.java
+++ b/src/test/java/org/jnode/fs/service/FileSystemService.java
@@ -9,26 +9,23 @@ import org.jnode.fs.apfs.ApfsFileSystemType;
 import org.jnode.fs.ext2.Ext2FileSystemType;
 import org.jnode.fs.hfsplus.HfsPlusFileSystemType;
 import org.jnode.fs.ntfs.NTFSFileSystemType;
+import org.jnode.fs.xfs.XfsFileSystemType;
 
-public class FileSystemService
-{
+public class FileSystemService {
     private static final Map<Class<?>, FileSystemType<?>> typeMap = ImmutableMap.<Class<?>, FileSystemType<?>>builder()
-                                                                                .put(Ext2FileSystemType.class, new Ext2FileSystemType())
-                                                                                .put(ApfsFileSystemType.class, new ApfsFileSystemType())
-                                                                                .put(HfsPlusFileSystemType.class, new HfsPlusFileSystemType())
-                                                                                .put(NTFSFileSystemType.class, new NTFSFileSystemType())
-                                                                                .build();
+            .put(Ext2FileSystemType.class, new Ext2FileSystemType())
+            .put(ApfsFileSystemType.class, new ApfsFileSystemType())
+            .put(HfsPlusFileSystemType.class, new HfsPlusFileSystemType())
+            .put(NTFSFileSystemType.class, new NTFSFileSystemType())
+            .put(XfsFileSystemType.class, new XfsFileSystemType())
+            .build();
 
     public <T extends FileSystemType<?>> T getFileSystemType(Class<T> name)
-        throws FileSystemException
-    {
+            throws FileSystemException {
         FileSystemType<?> type = typeMap.get(name);
-        if (type != null)
-        {
+        if (type != null) {
             return (T) type;
-        }
-        else
-        {
+        } else {
             throw new FileSystemException("Unhandled Filesystem type");
         }
     }

--- a/src/test/java/org/jnode/fs/xfs/XfsFileSystemTest.java
+++ b/src/test/java/org/jnode/fs/xfs/XfsFileSystemTest.java
@@ -1,102 +1,42 @@
 package org.jnode.fs.xfs;
 
-import org.jmock.auto.Mock;
-import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.jnode.driver.block.FileDevice;
-import org.jnode.fs.*;
-
+import org.jnode.fs.DataStructureAsserts;
+import org.jnode.fs.FileSystemTestUtils;
 import org.jnode.fs.service.FileSystemService;
-import org.jnode.fs.spi.FSEntryTable;
-
-import org.jnode.partitions.PartitionTableEntry;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.file.Files;
-
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public class XfsFileSystemTest {
 
     private FileSystemService fss;
-    XfsFileSystem fs;
 
     @Before
-    public void setUp() throws Exception
-    {
+    public void setUp() {
         // create file system service.
         fss = FileSystemTestUtils.createFSService(XfsFileSystemType.class.getName());
-
-        String [] xfsTestDirectory = { "/folder1", "/folder 2", "/testfile.txt" };
-        for ( String xfsEntryElement : xfsTestDirectory ) {
-            File file = new File("src/test/resources/"+xfsEntryElement).getAbsoluteFile();
-            FileSystemTestUtils.deleteDirectory(file);
-        }
     }
-
-    @Rule
-    public final JUnitRuleMockery mockery = new JUnitRuleMockery();
-
-    @Mock
-    PartitionTableEntry partitionTableEntry;
 
     @Test
-    public void testSupports() throws Exception
-    {
+    public void testImage1() throws Exception {
         File testFile = FileSystemTestUtils.getTestFile("org/jnode/fs/xfs/test-xfs-1.img");
 
-        try (FileDevice device = new FileDevice(testFile, "r"))
-        {
+        try (FileDevice device = new FileDevice(testFile, "r")) {
             XfsFileSystemType type = new XfsFileSystemType();
-            fs = type.create(device, true);
-            byte[] buffer = new byte[512];
-            assertThat(type.supports(partitionTableEntry, buffer, device), is(true));
+            XfsFileSystem fs = type.create(device, true);
 
-            XfsDirectory xfsdir = new XfsDirectory(fs.getRootEntry());
-            /**
-             * Table of entries of our parent
-             */
-            xfsdir.readEntries();
-            createXfsFileStructureFromTestImage(xfsdir,"");
-            String [] xfsEntriesArray = { "/folder1", "/folder 2","/folder1/this_is_fine.jpg", "/folder 2/xfs.zip","/testfile.txt" };
-            for ( String xfsEntryElement : xfsEntriesArray ) {
-                assertThat(FileSystemTestUtils.testIfExists( xfsEntryElement ), is(true));
-            }
-        }
-        finally
-        {
+            String expectedStructure = "type: XFS vol:null total:0 free:0\n" +
+                    "  /; \n" +
+                    "    folder1; \n" +
+                    "      this_is_fine.jpg; 53072; ee04081c3182a44a1c6944e94012e977\n" +
+                    "    folder 2; \n" +
+                    "      xfs.zip; 20103; d5f8c07fdff365b45b8af1ae7622a98d\n" +
+                    "    testfile.txt; 20; 5dd39cab1c53c2c77cd352983f9641e1\n";
+            DataStructureAsserts.assertStructure(fs, expectedStructure);
+        } finally {
             testFile.delete();
-        }
-    }
-
-    private void createXfsFileStructureFromTestImage(XfsDirectory inode,String str) throws IOException {
-
-        final FSEntryTable entries = inode.readEntries();
-        FileSystemTestUtils.createDirectory( str );
-        if (entries.size() == 0){
-            return;
-        }
-        for (int i = 0; i < entries.size(); i++) {
-            FSEntry current = entries.get(i);
-            XfsEntry xfsCurrentEntry = (XfsEntry) current;
-            if (( current.getName().equals("..") || current.getName().equals(".")) ) {
-                continue;
-            }
-            if (current.isFile()) {
-                File f = FileSystemTestUtils.createFile( str + "/" + current.getName() );
-                ByteBuffer allocate = ByteBuffer.allocate((int)xfsCurrentEntry.getINode().getSize());
-                xfsCurrentEntry.readUnchecked(0,allocate);
-                Files.write(f.toPath(), allocate.array() );
-            } else {
-                String str2 = str + "/" + current.getName();
-                createXfsFileStructureFromTestImage(new XfsDirectory(xfsCurrentEntry) ,str2);
-            }
         }
     }
 }

--- a/src/test/java/org/jnode/fs/xfs/XfsFileSystemTest.java
+++ b/src/test/java/org/jnode/fs/xfs/XfsFileSystemTest.java
@@ -24,7 +24,7 @@ public class XfsFileSystemTest {
         File testFile = FileSystemTestUtils.getTestFile("org/jnode/fs/xfs/test-xfs-1.img");
 
         try (FileDevice device = new FileDevice(testFile, "r")) {
-            XfsFileSystemType type = new XfsFileSystemType();
+            XfsFileSystemType type = fss.getFileSystemType(XfsFileSystemType.ID);
             XfsFileSystem fs = type.create(device, true);
 
             String expectedStructure = "type: XFS vol:null total:0 free:0\n" +


### PR DESCRIPTION
@JulioCesarParra it looks like the test style used by ext4 can be applied to the XfsFileSystemTest class. This is what I was expecting. 
Note that the "type: XFS" line contains values for "vol", "total", and "free" which I think will be filled in when the stub functions in class XfsFileSystem are done.